### PR TITLE
patch: Replaced text with empty data property using SizedBox.shrink().

### DIFF
--- a/lib/src/ui/widgets/text.dart
+++ b/lib/src/ui/widgets/text.dart
@@ -49,15 +49,19 @@ class _DuitControlledTextState extends State<DuitControlledText>
 
   @override
   Widget build(BuildContext context) {
-    return Text(
-      attributes?.data ?? "",
-      textAlign: attributes?.textAlign,
-      textDirection: attributes?.textDirection,
-      style: attributes?.style,
-      maxLines: attributes?.maxLines,
-      semanticsLabel: attributes?.semanticsLabel,
-      overflow: attributes?.overflow,
-      softWrap: attributes?.softWrap,
-    );
+    if (attributes?.data == null || attributes!.data!.isEmpty) {
+      return const SizedBox.shrink();
+    } else {
+      return Text(
+        attributes?.data ?? "",
+        textAlign: attributes?.textAlign,
+        textDirection: attributes?.textDirection,
+        style: attributes?.style,
+        maxLines: attributes?.maxLines,
+        semanticsLabel: attributes?.semanticsLabel,
+        overflow: attributes?.overflow,
+        softWrap: attributes?.softWrap,
+      );
+    }
   }
 }


### PR DESCRIPTION
Changed the behavior of the DuitText widget. If the data property is null or an empty string, then SizedBox.shrink is returned instead of the Text widget