### PR TITLE
fix: incorrect controllers creation/destruction

### DIFF
--- a/lib/src/controller/view_controller.dart
+++ b/lib/src/controller/view_controller.dart
@@ -113,4 +113,10 @@ final class ViewController<T>
       rethrow;
     }
   }
+
+  @override
+  void dispose() {
+    driver.detachController(this.id);
+    super.dispose();
+  }
 }

--- a/lib/src/duit_impl/driver.dart
+++ b/lib/src/duit_impl/driver.dart
@@ -241,8 +241,8 @@ final class DuitDriver with DriverHooks implements UIDriver {
   //<editor-fold desc="Actions & Events">
   /// Resolves a server event from a JSON object.
   ///
-  /// This method takes a [json] object representing a server event and converts
-  /// it into a [ServerEvent] object. If the [json] object is valid and represents
+  /// This method takes a [eventData] object representing a server event and converts
+  /// it into a [ServerEvent] object. If the [eventData] object is valid and represents
   /// a recognized server event type, it creates an instance of the corresponding
   /// event class and assigns it to the [event] variable.
   ///
@@ -250,8 +250,15 @@ final class DuitDriver with DriverHooks implements UIDriver {
   /// - [json]: The JSON object representing a server event.
   ///
   /// Returns: A [Future] that completes with [void].
-  FutureOr<void> _resolveEvent(JSONObject? json) async {
-    final event = ServerEvent.fromJson(json, this);
+  FutureOr<void> _resolveEvent(dynamic eventData) async {
+    ServerEvent? event;
+
+    if (eventData is ServerEvent) {
+      event = eventData;
+    } else {
+      event = ServerEvent.fromJson(eventData, this);
+    }
+
     onEventReceived?.call(event);
     if (event != null) {
       switch (event.type) {
@@ -588,9 +595,11 @@ final class DuitDriver with DriverHooks implements UIDriver {
   }
 
   @visibleForTesting
-  Future<void> resolveTestEvent(Map<String, dynamic>? json) async {
-    await _resolveEvent(json);
+  Future<void> resolveTestEvent(dynamic eventData) async {
+    await _resolveEvent(eventData);
   }
 
+  @visibleForTesting
+  int get controllersCount => _viewControllers.length;
 //</editor-fold>
 }

--- a/lib/src/duit_impl/subtree_holder.dart
+++ b/lib/src/duit_impl/subtree_holder.dart
@@ -42,6 +42,7 @@ mixin SubtreeHolder<T extends StatefulWidget> on State<T> {
   @override
   void dispose() {
     _controller?.removeListener(_listener);
+    _controller?.dispose();
     super.dispose();
   }
 }

--- a/lib/src/duit_impl/view_controller_change_listener.dart
+++ b/lib/src/duit_impl/view_controller_change_listener.dart
@@ -99,6 +99,7 @@ mixin ViewControllerChangeListener<T extends StatefulWidget,
   @override
   void dispose() {
     _controller.removeListener(_listener);
+    _controller.dispose();
     super.dispose();
   }
 }

--- a/test/d_listview_test.dart
+++ b/test/d_listview_test.dart
@@ -1,0 +1,180 @@
+import "package:duit_kernel/duit_kernel.dart";
+import "package:flutter/material.dart";
+import "package:flutter_duit/flutter_duit.dart";
+import "package:flutter_test/flutter_test.dart";
+
+Map<String, dynamic> _createWidget() {
+  return {
+    "controlled": true,
+    "id": "87b54621-ac6d-42c3-8d1f-397e3bd63bca",
+    "type": "ListView",
+    "attributes": {
+      "type": 1,
+      "childObjects": [
+        {
+          "controlled": true,
+          "action": null,
+          "id": "1",
+          "type": "Component",
+          "data": {
+            "come": "value",
+          },
+          "tag": "c"
+        },
+        {
+          "controlled": true,
+          "action": null,
+          "id": "2",
+          "type": "Component",
+          "data": {
+            "come": "value",
+          },
+          "tag": "c"
+        },
+        {
+          "controlled": true,
+          "action": null,
+          "id": "3",
+          "type": "Component",
+          "data": {
+            "come": "value",
+          },
+          "tag": "c"
+        },
+        {
+          "controlled": true,
+          "action": null,
+          "id": "4",
+          "type": "Component",
+          "data": {
+            "come": "value",
+          },
+          "tag": "c"
+        },
+        {
+          "controlled": true,
+          "action": null,
+          "id": "5",
+          "type": "Component",
+          "data": {
+            "come": "value",
+          },
+          "tag": "c"
+        },
+        {
+          "controlled": true,
+          "action": null,
+          "id": "6",
+          "type": "Component",
+          "data": {
+            "come": "value",
+          },
+          "tag": "c"
+        },
+        {
+          "controlled": true,
+          "action": null,
+          "id": "7",
+          "type": "Component",
+          "data": {
+            "come": "value",
+          },
+          "tag": "c"
+        },
+        {
+          "controlled": true,
+          "action": null,
+          "id": "8",
+          "type": "Component",
+          "data": {
+            "come": "value",
+          },
+          "tag": "c"
+        },
+        {
+          "controlled": true,
+          "action": null,
+          "id": "9",
+          "type": "Component",
+          "data": {
+            "come": "value",
+          },
+          "tag": "c"
+        },
+        {
+          "controlled": true,
+          "action": null,
+          "id": "10",
+          "type": "Component",
+          "data": {
+            "come": "value",
+          },
+          "tag": "c"
+        }
+      ],
+      "shrinkWrap": true
+    }
+  };
+}
+
+void main() {
+  DuitRegistry.registerComponents([
+    {
+      "tag": "c",
+      "layoutRoot": {
+        "type": "Container",
+        "tag": "c",
+        "id": "ckk",
+        "controlled": false,
+        "attributes": {
+          "color": "#DCDCDC",
+          "width": 100,
+          "height": 1000,
+        },
+      },
+    }
+  ]);
+
+  testWidgets(
+      "Checking the correct creation and destruction of component controllers when scrolling in ListView.builder",
+      (tester) async {
+    final driver = DuitDriver.static(
+      _createWidget(),
+      transportOptions: HttpTransportOptions(),
+      enableDevMetrics: false,
+    );
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: DuitViewHost(
+          driver: driver,
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final scroll = find.byType(Scrollable);
+    final itemFirst = find.byKey(const ValueKey("1"));
+    final itemLast = find.byKey(const ValueKey("10"));
+
+    await tester.scrollUntilVisible(
+      itemLast,
+      1000,
+      scrollable: scroll,
+    );
+
+    expect(itemLast, findsOneWidget);
+    expect(driver.controllersCount == 10, false);
+
+    await tester.scrollUntilVisible(
+      itemFirst,
+      -1000,
+      scrollable: scroll,
+    );
+
+    expect(itemFirst, findsOneWidget);
+    expect(driver.controllersCount == 10, false);
+  });
+}

--- a/test/d_single_child_scroll_view_test.dart
+++ b/test/d_single_child_scroll_view_test.dart
@@ -1,0 +1,66 @@
+import "package:flutter/material.dart";
+import "package:flutter_duit/flutter_duit.dart";
+import "package:flutter_test/flutter_test.dart";
+
+Map<String, dynamic> _createWidget1() {
+  return {
+    "type": "SingleChildScrollView",
+    "attributes": {},
+    "controlled": false,
+    "id": "scr",
+    "child": {
+      "type": "Column",
+      "attributes": {},
+      "controlled": false,
+      "id": "col",
+      "children": List.generate(
+        100,
+        (i) => {
+          "type": "Container",
+          "id": "c$i",
+          "controlled": i % 2 == 0 ? true : false,
+          "attributes": {
+            "height": "150",
+            "width": "150",
+            "color": "#DCDCDC",
+          },
+        } as Map<String, dynamic>,
+      ),
+    },
+  };
+}
+
+void main() {
+  testWidgets('SingleChildScrollView scrolls correctly', (WidgetTester tester) async {
+    final driver = DuitDriver.static(
+      _createWidget1(),
+      transportOptions: HttpTransportOptions(),
+      enableDevMetrics: false,
+    );
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: DuitViewHost(
+          driver: driver,
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(driver.controllersCount, 50);
+
+    final scrollView = find.byType(Scrollable);
+
+    await tester.scrollUntilVisible(
+      find.byKey(const ValueKey("c50")),
+      150.0,
+      scrollable: scrollView,
+    );
+    await tester.pumpAndSettle();
+
+    expect(scrollView, findsOneWidget);
+    expect(find.byKey(const ValueKey("c50")), findsOneWidget);
+  });
+}

--- a/test/d_subtree_test.dart
+++ b/test/d_subtree_test.dart
@@ -1,0 +1,147 @@
+import "package:flutter/material.dart";
+import "package:flutter_duit/flutter_duit.dart";
+import "package:flutter_test/flutter_test.dart";
+
+const _t1 = {
+  "type": "Text",
+  "id": "tfgdfg1",
+  "controlled": true,
+  "attributes": {"data": "Text 1"}
+};
+
+const _t2 = {
+  "type": "Text",
+  "id": "fgfgfbcb",
+  "controlled": false,
+  "attributes": {"data": "Text 2"}
+};
+
+Map<String, dynamic> _createWidget() {
+  return {
+    "type": "Column",
+    "attributes": {},
+    "controlled": false,
+    "id": "col",
+    "children": [
+      {
+        "type": "ElevatedButton",
+        "id": "button1",
+        "controlled": true,
+        "action": {
+          "executionType": 1, //local
+          "event": "local_exec",
+          "payload": {
+            "type": "update",
+            "updates": {
+              "subtree": _t1,
+            }
+          }
+        },
+        "attributes": {
+          "autofocus": false,
+        },
+        "child": {
+          "type": "Text",
+          "id": "t1dvv",
+          "controlled": true,
+          "attributes": {
+            "data": "Press me!",
+            "style": {
+              "fontSize": 12.0,
+              "fontWeight": 400,
+            }
+          },
+        }
+      },
+      {
+        "type": "ElevatedButton",
+        "id": "button2",
+        "controlled": true,
+        "action": {
+          "executionType": 1, //local
+          "event": "local_exec",
+          "payload": {
+            "type": "update",
+            "updates": {
+              "subtree": _t2,
+            }
+          }
+        },
+        "attributes": {
+          "autofocus": false,
+        },
+        "child": {
+          "type": "Text",
+          "id": "vssww",
+          "controlled": true,
+          "attributes": {
+            "data": "Press me!",
+            "style": {
+              "fontSize": 12.0,
+              "fontWeight": 400,
+            }
+          },
+        }
+      },
+      {
+        "type": "Subtree",
+        "id": "subtree",
+        "controlled": true,
+        "attributes": {},
+        "child": {
+          "type": "Empty",
+          "id": "t1x",
+          "attributes": {}
+        }
+      }
+    ]
+  };
+}
+
+void main() {
+  group(
+    "DuitSubtree widget tests",
+    () {
+      testWidgets(
+        "Check subtree content changed correctly after toggle",
+        (tester) async {
+          await tester.pumpWidget(
+            Directionality(
+              textDirection: TextDirection.ltr,
+              child: DuitViewHost(
+                driver: DuitDriver.static(
+                  _createWidget(),
+                  transportOptions: HttpTransportOptions(),
+                  enableDevMetrics: false,
+                ),
+              ),
+            ),
+          );
+
+          await tester.pumpAndSettle();
+
+          final button1 = find.byKey(const Key("button1"));
+          final button2 = find.byKey(const Key("button2"));
+
+          expect(button1, findsOneWidget);
+          expect(button2, findsOneWidget);
+          expect(find.text("Text 1"), findsNothing);
+
+          await tester.tap(button2);
+          await tester.pumpAndSettle();
+
+          expect(find.text("Text 2"), findsOneWidget);
+
+          await tester.tap(button1);
+          await tester.pumpAndSettle();
+          await tester.tap(button2);
+          await tester.pumpAndSettle();
+          await tester.tap(button1);
+          await tester.pumpAndSettle();
+
+          expect(find.text("Text 1"), findsOneWidget);
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
Fixed issue with incorrect controller destruction while render content of subtree widget, added tests for check correct controllers creation/destruction in most cases