### PR TITLE
patch: Custom widget controller auto-typecast 

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -15,6 +15,8 @@ class CustomDecoder extends Converter<Uint8List, Map<String, dynamic>> {
 }
 
 final class _Handler implements ExternalEventHandler {
+  const _Handler();
+
   @override
   FutureOr<void> handleCustomEvent(
       BuildContext context, String key, Object? extra) {
@@ -104,7 +106,7 @@ class _MyHomePageState extends State<MyHomePage> {
         baseUrl: "http://localhost:8999",
         decoder: CustomDecoder(),
       ),
-      eventHandler: _Handler(),
+      externalEventHandler: const _Handler(),
     );
     super.initState();
   }

--- a/example/lib/src/custom/example/factories.dart
+++ b/example/lib/src/custom/example/factories.dart
@@ -23,7 +23,7 @@ Widget exBuildFactory(
   }
 
   return ExampleWidget(
-    controller: m.viewController!.cast<ExampleCustomWidgetAttributes>(),
+    controller: m.viewController!,
     child: child,
   );
 }

--- a/example/lib/src/custom/example/model.dart
+++ b/example/lib/src/custom/example/model.dart
@@ -1,8 +1,10 @@
+import 'package:example/src/custom/example/attributes.dart';
 import 'package:example/src/custom/index.dart';
 import 'package:flutter_duit/flutter_duit.dart';
 
 // Use CustomUiElement instead of DuitElement
-final class ExampleCustomWidget extends CustomUiElement {
+final class ExampleCustomWidget
+    extends CustomUiElement<ExampleCustomWidgetAttributes> {
   ExampleCustomWidget({
     required super.id,
     required super.attributes,

--- a/lib/src/ui/models/element_models.dart
+++ b/lib/src/ui/models/element_models.dart
@@ -289,18 +289,20 @@ final class StackUIElement<T> extends DuitElement<T>
   });
 }
 
-base class CustomUiElement extends DuitElement<dynamic> {
+base class CustomUiElement<T> extends DuitElement<T> {
   final Iterable<ElementTreeEntry> subviews;
 
   CustomUiElement({
     required super.id,
     required super.controlled,
-    required super.viewController,
-    required super.attributes,
+    required UIElementController? viewController,
+    required ViewAttribute? attributes,
     required super.tag,
     this.subviews = const {},
   }) : super(
           type: ElementType.custom,
+          viewController: viewController?.cast<T>(),
+          attributes: attributes?.cast<T>(),
         );
 }
 


### PR DESCRIPTION
## Description

- Added automatic type cast on custom widget model instance creating (no longer required to manually cast types or call the controller's `cast ` method)
- Edit example app

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
