### PR TITLE
patch:  Rebinding the controller after type casting

### DIFF
--- a/.github/workflows/duit_pr.yaml
+++ b/.github/workflows/duit_pr.yaml
@@ -2,13 +2,13 @@ name: Duit PR CI
 
 on: [pull_request]
 
-env:
-  IS_CI: true
-  FLUTTER_VERSION: "3.22.3"
-
 jobs:
   run-tests:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        flutter-version: [ '3.22.3', '3.24.3', '3.27.3' ]
     steps:
       - name: Checkout repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -16,10 +16,10 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
+          flutter-version: ${{ matrix.flutter-version }}
           channel: 'stable'
           cache: true
       - run: flutter pub get
-      - run: flutter test --no-pub --coverage --test-randomize-ordering-seed=random
+      - run: flutter test --no-pub --test-randomize-ordering-seed=random
     permissions:
       id-token: write

--- a/lib/src/controller/view_controller.dart
+++ b/lib/src/controller/view_controller.dart
@@ -162,7 +162,7 @@ final class ViewController<T>
 
   @override
   UIElementController<R> cast<R>() {
-    return ViewController(
+    final controller = ViewController(
       id: id,
       driver: driver,
       type: type,
@@ -170,5 +170,10 @@ final class ViewController<T>
       action: action,
       tag: tag,
     );
+
+    //re-attach new controller instance
+    driver.attachController(id, controller);
+
+    return controller;
   }
 }

--- a/test/d_component_test.dart
+++ b/test/d_component_test.dart
@@ -6,7 +6,11 @@ import "package:flutter_test/flutter_test.dart";
 import "mocks/component_template.dart";
 
 void main() {
-  DuitRegistry.registerComponents([componentTemplate]);
+  setUpAll(
+    () async {
+      await DuitRegistry.registerComponents([componentTemplate]);
+    },
+  );
 
   group("DuitComponent widget tests", () {
     testWidgets("must merge with data correctly", (tester) async {

--- a/test/d_custom_test.dart
+++ b/test/d_custom_test.dart
@@ -1,0 +1,114 @@
+import "package:flutter/material.dart";
+import "package:flutter_duit/flutter_duit.dart";
+import "package:flutter_test/flutter_test.dart";
+
+import "mocks/custom.dart";
+
+void main() {
+  group(
+    "Custom widget tests",
+    () {
+      setUpAll(() {
+        regCustom();
+      });
+
+      testWidgets(
+        "must create custom widget",
+        (t) async {
+          final driver = DuitDriver.static(
+            {
+              "type": "Custom",
+              "tag": exampleCustomWidget,
+              "attributes": {},
+              "id": "custom",
+              "controlled": true,
+            },
+            transportOptions: EmptyTransportOptions(),
+          );
+
+          await t.pumpWidget(
+            Directionality(
+              textDirection: TextDirection.ltr,
+              child: DuitViewHost(
+                driver: driver,
+              ),
+            ),
+          );
+
+          await t.pumpAndSettle();
+
+          expect(find.byType(Text), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        "must update custom widget",
+        (t) async {
+          final driver = DuitDriver.static(
+            {
+              "type": "Custom",
+              "tag": exampleCustomWidget,
+              "attributes": {},
+              "id": "custom",
+              "controlled": true,
+            },
+            transportOptions: EmptyTransportOptions(),
+          );
+
+          await t.pumpWidget(
+            Directionality(
+              textDirection: TextDirection.ltr,
+              child: DuitViewHost(
+                driver: driver,
+              ),
+            ),
+          );
+
+          await t.pumpAndSettle();
+
+          expect(find.byType(Text), findsOneWidget);
+
+          await driver.updateTestAttributes(
+            "custom",
+            {
+              "random": "value",
+            },
+          );
+
+          await t.pumpAndSettle();
+
+          expect(find.text("value"), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        "must create empty view when invalid tag provided",
+        (t) async {
+          final driver = DuitDriver.static(
+            {
+              "type": "Custom",
+              "tag": "invalid_tag",
+              "attributes": {},
+              "id": "custom",
+              "controlled": true,
+            },
+            transportOptions: EmptyTransportOptions(),
+          );
+
+          await t.pumpWidget(
+            Directionality(
+              textDirection: TextDirection.ltr,
+              child: DuitViewHost(
+                driver: driver,
+              ),
+            ),
+          );
+
+          await t.pumpAndSettle();
+
+          expect(find.byType(SizedBox), findsOneWidget);
+        },
+      );
+    },
+  );
+}

--- a/test/d_listview_test.dart
+++ b/test/d_listview_test.dart
@@ -117,22 +117,26 @@ Map<String, dynamic> _createWidget() {
 }
 
 void main() {
-  DuitRegistry.registerComponents([
-    {
-      "tag": "c",
-      "layoutRoot": {
-        "type": "Container",
-        "tag": "c",
-        "id": "ckk",
-        "controlled": false,
-        "attributes": {
-          "color": "#DCDCDC",
-          "width": 100,
-          "height": 1000,
-        },
-      },
-    }
-  ]);
+  setUpAll(
+    () async {
+      await DuitRegistry.registerComponents([
+        {
+          "tag": "c",
+          "layoutRoot": {
+            "type": "Container",
+            "tag": "c",
+            "id": "ckk",
+            "controlled": false,
+            "attributes": {
+              "color": "#DCDCDC",
+              "width": 100,
+              "height": 1000,
+            },
+          },
+        }
+      ]);
+    },
+  );
 
   testWidgets(
       "Checking the correct creation and destruction of component controllers when scrolling in ListView.builder",

--- a/test/mocks/custom.dart
+++ b/test/mocks/custom.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_duit/flutter_duit.dart';
+
+final class ExampleCustomWidgetAttributes extends AnimatedPropertyOwner
+    implements DuitAttributes<ExampleCustomWidgetAttributes> {
+  final String? random;
+
+  ExampleCustomWidgetAttributes({
+    required this.random,
+    required super.parentBuilderId,
+    required super.affectedProperties,
+  });
+
+  factory ExampleCustomWidgetAttributes.fromJson(Map<String, dynamic> json) {
+    final view = AnimatedPropHelper(json);
+
+    return ExampleCustomWidgetAttributes(
+      random: view["random"],
+      parentBuilderId: view.parentBuilderId,
+      affectedProperties: view.affectedProperties,
+    );
+  }
+
+  @override
+  ExampleCustomWidgetAttributes copyWith(other) {
+    return ExampleCustomWidgetAttributes(
+        random: other.random ?? random,
+        parentBuilderId: other.parentBuilderId ?? parentBuilderId,
+        affectedProperties: other.affectedProperties ?? affectedProperties);
+  }
+
+  @override
+  ReturnT dispatchInternalCall<ReturnT>(
+    String methodName, {
+    Iterable? positionalParams,
+    Map<String, dynamic>? namedParams,
+  }) {
+    return switch (methodName) {
+      "fromJson" =>
+        ExampleCustomWidgetAttributes.fromJson(positionalParams!.first)
+            as ReturnT,
+      String() => throw UnimplementedError("$methodName is not implemented"),
+    };
+  }
+}
+
+const exampleCustomWidget = "ExampleCustomWidget";
+
+DuitAttributes exAttributeFactory(
+  String type,
+  Map<String, dynamic>? json,
+) {
+  return ExampleCustomWidgetAttributes.fromJson(json ?? {});
+}
+
+Widget exBuildFactory(
+  ElementTreeEntry model, [
+  Iterable<Widget> subviews = const [],
+]) {
+  final m = model as ExampleCustomWidget;
+  Widget? child;
+
+  if (subviews.isNotEmpty) {
+    child = subviews.first;
+  }
+
+  return ExampleWidget(
+    controller: m.viewController!,
+    child: child,
+  );
+}
+
+ElementTreeEntry exModelFactory(
+  String id,
+  bool controlled,
+  ViewAttribute attributes,
+  UIElementController? controller, [
+  Iterable<ElementTreeEntry> subviews = const [],
+]) {
+  return ExampleCustomWidget(
+    id: id,
+    attributes: attributes,
+    viewController: controller,
+    controlled: controlled,
+    subviews: subviews,
+  );
+}
+
+final class ExampleCustomWidget
+    extends CustomUiElement<ExampleCustomWidgetAttributes> {
+  ExampleCustomWidget({
+    required super.id,
+    required super.attributes,
+    required super.viewController,
+    required super.controlled,
+    required super.subviews,
+  }) : super(
+          tag: exampleCustomWidget,
+        );
+}
+
+class ExampleWidget extends StatefulWidget {
+  final Widget? child;
+  final UIElementController<ExampleCustomWidgetAttributes> controller;
+
+  ExampleWidget({
+    super.key,
+    required UIElementController controller,
+    this.child,
+  }) : controller = controller.cast<ExampleCustomWidgetAttributes>();
+
+  @override
+  State<ExampleWidget> createState() => _ExampleWidgetState();
+}
+
+class _ExampleWidgetState extends State<ExampleWidget>
+    with
+        ViewControllerChangeListener<ExampleWidget,
+            ExampleCustomWidgetAttributes> {
+  @override
+  void initState() {
+    attachStateToController(
+      widget.controller,
+    );
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.green,
+      padding: const EdgeInsets.all(12),
+      child: Column(
+        children: [
+          Text(attributes.random ?? ""),
+          widget.child ??
+              Container(
+                color: Colors.red,
+                width: 25,
+                height: 25,
+              ),
+        ],
+      ),
+    );
+  }
+}
+
+void regCustom() {
+  DuitRegistry.configure();
+  DuitRegistry.register(
+    exampleCustomWidget,
+    modelFactory: exModelFactory,
+    buildFactory: exBuildFactory,
+    attributesFactory: exAttributeFactory,
+  );
+}


### PR DESCRIPTION
## Description

- Fixed a bug where the controller was not bound to the driver after type casting
- Added tests for custom widgets

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
