### PR TITLE
patch: passing Scaffold body property through widget child instead of attributes

### DIFF
--- a/lib/src/attributes/scaffold_attributes.dart
+++ b/lib/src/attributes/scaffold_attributes.dart
@@ -4,7 +4,6 @@ import 'package:flutter_duit/flutter_duit.dart';
 final class ScaffoldAttributes implements DuitAttributes<ScaffoldAttributes> {
   //TODO: implement Drawer and related props
   final NonChildWidget? appBar,
-      body,
       bottomNavigationBar,
       floatingActionButton,
       bottomSheet;
@@ -25,7 +24,6 @@ final class ScaffoldAttributes implements DuitAttributes<ScaffoldAttributes> {
     required this.persistentFooterAlignment,
     this.appBar,
     this.backgroundColor,
-    this.body,
     this.bottomNavigationBar,
     // this.drawer,
     // this.endDrawer,
@@ -45,7 +43,6 @@ final class ScaffoldAttributes implements DuitAttributes<ScaffoldAttributes> {
       appBar: json["appBar"],
       backgroundColor:
           ColorUtils.tryParseNullableColor(json["backgroundColor"]),
-      body: json["body"],
       bottomNavigationBar: json["bottomNavigationBar"],
       // drawer: json["drawer"],
       // endDrawer: json["endDrawer"],
@@ -73,7 +70,6 @@ final class ScaffoldAttributes implements DuitAttributes<ScaffoldAttributes> {
         primary: other.primary,
         appBar: other.appBar ?? appBar,
         backgroundColor: other.backgroundColor ?? backgroundColor,
-        body: other.body ?? body,
         bottomNavigationBar: other.bottomNavigationBar ?? bottomNavigationBar,
         // drawer: other.drawer ?? drawer,
         // endDrawer: other.endDrawer ?? endDrawer,

--- a/lib/src/ui/models/element.dart
+++ b/lib/src/ui/models/element.dart
@@ -1439,6 +1439,8 @@ base class DuitElement<T> extends ElementTreeEntry<T> with WidgetFabric {
           controlled: true,
         );
       case ElementType.scaffold:
+        final child = DuitElement.fromJson(json["child"], driver);
+
         final attributes = ViewAttribute.createAttributes<ScaffoldAttributes>(
           type,
           attributesObject,
@@ -1459,6 +1461,7 @@ base class DuitElement<T> extends ElementTreeEntry<T> with WidgetFabric {
             tag,
           ),
           controlled: true,
+          child: child,
         );
       case ElementType.inkWell:
         final child = DuitElement.fromJson(json["child"], driver);

--- a/lib/src/ui/models/element_models.dart
+++ b/lib/src/ui/models/element_models.dart
@@ -855,12 +855,17 @@ final class AppBarUiElement<T> extends DuitElement<T> {
   });
 }
 
-final class ScaffoldUiElement<T> extends DuitElement<T> {
+final class ScaffoldUiElement<T> extends DuitElement<T>
+    implements SingleChildLayout {
+  @override
+  DuitElement child;
+
   ScaffoldUiElement({
     required super.type,
     required super.id,
     required super.controlled,
     required super.viewController,
+    required this.child,
   });
 }
 

--- a/lib/src/ui/widgets/scaffold.dart
+++ b/lib/src/ui/widgets/scaffold.dart
@@ -4,10 +4,12 @@ import 'package:flutter_duit/src/attributes/index.dart';
 
 class DuitScaffold extends StatefulWidget {
   final UIElementController<ScaffoldAttributes> controller;
+  final Widget child;
 
   const DuitScaffold({
     super.key,
     required this.controller,
+    required this.child,
   });
 
   @override
@@ -34,11 +36,7 @@ class _DuitScaffoldState extends State<DuitScaffold>
         driver,
         null,
       ),
-      body: buildOutOfBoundWidget(
-        attributes.body,
-        driver,
-        null,
-      ),
+      body: widget.child,
       floatingActionButton: buildOutOfBoundWidget(
         attributes.floatingActionButton,
         driver,

--- a/lib/src/ui/widgets/widget_fabric.dart
+++ b/lib/src/ui/widgets/widget_fabric.dart
@@ -617,9 +617,11 @@ mixin WidgetFabric {
         );
       case ElementType.scaffold:
         final it = model as ScaffoldModel;
+        final child = getWidgetFromElement(it.child);
 
         return DuitScaffold(
           controller: it.viewController!,
+          child: child,
         );
       case ElementType.inkWell:
         final it = model as InkWellModel;

--- a/test/d_scaffold_test.dart
+++ b/test/d_scaffold_test.dart
@@ -43,14 +43,13 @@ void main() {
             {
               "type": "Scaffold",
               "id": "scaffold",
-              "attributes": {
-                "body": {
-                  "type": "Text",
-                  "id": "text",
-                  "controlled": false,
-                  "attributes": {
-                    "data": "Hello, world!",
-                  },
+              "attributes": {},
+              "child": {
+                "type": "Text",
+                "id": "text",
+                "controlled": false,
+                "attributes": {
+                  "data": "Hello, world!",
                 },
               },
             },


### PR DESCRIPTION
## Description

- Removed body prop from ScaffoldAttributes, pass body from child model propery

## Issue

#261 

## Related PRs

https://github.com/Duit-Foundation/duit_js/pull/112
https://github.com/Duit-Foundation/duit_go/pull/106

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
