### PR TITLE
patch: fixed `onEnd` callback on implicitly animated widgets 

### DIFF
--- a/lib/src/animations/on_animation_end.dart
+++ b/lib/src/animations/on_animation_end.dart
@@ -1,17 +1,18 @@
+import "dart:async";
+
 import "package:flutter/foundation.dart";
 import "package:flutter_duit/flutter_duit.dart";
 import "package:flutter_duit/src/animations/index.dart";
 
 mixin OnAnimationEnd {
   VoidCallback? onEndHandler<T extends ImplicitAnimatable>(
-    UIElementController<T> controller,
+    ServerAction? action,
+    FutureOr<void> Function(ServerAction? action) performFn,
   ) {
-    final action = controller.attributes.payload.onEnd;
-
     if (action == null) {
       return null;
     }
 
-    return () => controller.performAction(action);
+    return () => performFn(action);
   }
 }

--- a/lib/src/attributes/align_attributes.dart
+++ b/lib/src/attributes/align_attributes.dart
@@ -95,7 +95,7 @@ final class AnimatedAlignAttributes extends ImplicitAnimatable
       heightFactor: other.heightFactor ?? heightFactor,
       duration: duration,
       curve: other.curve,
-      onEnd: other.onEnd,
+      onEnd: other.onEnd ?? onEnd,
     );
   }
 

--- a/lib/src/attributes/animated_rotation_attributes.dart
+++ b/lib/src/attributes/animated_rotation_attributes.dart
@@ -39,7 +39,7 @@ final class AnimatedRotationAttributes extends ImplicitAnimatable
       alignment: other.alignment,
       duration: other.duration,
       curve: other.curve,
-      onEnd: other.onEnd,
+      onEnd: other.onEnd ?? onEnd,
       filterQuality: other.filterQuality ?? filterQuality, 
     );
   }

--- a/lib/src/attributes/animated_scale_attributes.dart
+++ b/lib/src/attributes/animated_scale_attributes.dart
@@ -38,7 +38,7 @@ final class AnimatedScaleAttributes extends ImplicitAnimatable
       alignment: other.alignment,
       duration: other.duration,
       curve: other.curve,
-      onEnd: other.onEnd,
+      onEnd: other.onEnd ?? onEnd,
       filterQuality: other.filterQuality ?? filterQuality,
     );
   }

--- a/lib/src/attributes/animation_attributes/animated_size_attributes.dart
+++ b/lib/src/attributes/animation_attributes/animated_size_attributes.dart
@@ -1,41 +1,44 @@
 import 'package:duit_kernel/duit_kernel.dart';
 import "package:flutter/material.dart";
+import 'package:flutter_duit/src/animations/index.dart';
 import 'package:flutter_duit/src/utils/index.dart';
 
-final class AnimatedSizeAttributes
+final class AnimatedSizeAttributes extends ImplicitAnimatable
     implements DuitAttributes<AnimatedSizeAttributes> {
-  final Duration duration, reverseDuration;
+  final Duration reverseDuration;
   final Clip? clipBehavior;
-  final Curve curve;
   final AlignmentGeometry? alignment;
 
   AnimatedSizeAttributes({
-    required this.duration,
+    required super.duration,
     required this.reverseDuration,
     required this.clipBehavior,
-    required this.curve,
+    super.curve,
     required this.alignment,
+    super.onEnd,
   });
 
   factory AnimatedSizeAttributes.fromJson(Map<String, dynamic> json) {
     assert(json['duration'] != null, "Duration cannot be null");
     return AnimatedSizeAttributes(
-      duration: AttributeValueMapper.toDuration(json['duration']),
       reverseDuration: AttributeValueMapper.toDuration(json['reverseDuration']),
       clipBehavior: AttributeValueMapper.toClip(json['clipBehavior']),
-      curve: AttributeValueMapper.toCurve(json['curve']),
       alignment: AttributeValueMapper.toAlignment(json['alignment']),
+      duration: AttributeValueMapper.toDuration(json['duration']),
+      curve: AttributeValueMapper.toCurve(json['curve']),
+      onEnd: ActionUtils(json).parseAction('onEnd'),
     );
   }
 
   @override
   AnimatedSizeAttributes copyWith(AnimatedSizeAttributes other) {
     return AnimatedSizeAttributes(
-      duration: other.duration,
+      duration: duration,
       reverseDuration: other.reverseDuration,
       clipBehavior: other.clipBehavior,
       curve: other.curve,
       alignment: other.alignment,
+      onEnd: other.onEnd ?? onEnd,
     );
   }
 
@@ -44,11 +47,6 @@ final class AnimatedSizeAttributes
     String methodName, {
     Iterable? positionalParams,
     Map<String, dynamic>? namedParams,
-  }) {
-    return switch (methodName) {
-      "fromJson" =>
-        AnimatedSizeAttributes.fromJson(positionalParams!.first) as ReturnT,
-      String() => throw UnimplementedError("$methodName is not implemented"),
-    };
-  }
+  }) =>
+      throw UnimplementedError();
 }

--- a/lib/src/attributes/container_attributes.dart
+++ b/lib/src/attributes/container_attributes.dart
@@ -185,7 +185,7 @@ final class AnimatedContainerAttributes extends ImplicitAnimatable
       foregroundDecoration: other.foregroundDecoration ?? foregroundDecoration,
       duration: duration, //copy prohibited
       curve: other.curve,
-      onEnd: other.onEnd,
+      onEnd: other.onEnd ?? onEnd,
     );
   }
 

--- a/lib/src/attributes/opacity_attributes.dart
+++ b/lib/src/attributes/opacity_attributes.dart
@@ -81,7 +81,7 @@ final class AnimatedOpacityAttributes extends ImplicitAnimatable
       opacity: other.opacity,
       duration: other.duration,
       curve: other.curve,
-      onEnd: other.onEnd,
+      onEnd: other.onEnd ?? onEnd,
     );
   }
 

--- a/lib/src/attributes/padding_attributes.dart
+++ b/lib/src/attributes/padding_attributes.dart
@@ -81,7 +81,7 @@ final class AnimatedPaddingAttributes extends ImplicitAnimatable
       padding: other.padding,
       duration: other.duration,
       curve: other.curve,
-      onEnd: other.onEnd,
+      onEnd: other.onEnd ?? onEnd,
     );
   }
 

--- a/lib/src/ui/widgets/implicit_animations/animated_align.dart
+++ b/lib/src/ui/widgets/implicit_animations/animated_align.dart
@@ -20,7 +20,8 @@ class DuitAnimatedAlign extends StatefulWidget {
 class _DuitAnimatedAlignState extends State<DuitAnimatedAlign>
     with
         ViewControllerChangeListener<DuitAnimatedAlign,
-            AnimatedAlignAttributes>, OnAnimationEnd {
+            AnimatedAlignAttributes>,
+        OnAnimationEnd {
   @override
   void initState() {
     attachStateToController(widget.controller);
@@ -36,7 +37,10 @@ class _DuitAnimatedAlignState extends State<DuitAnimatedAlign>
       heightFactor: attributes.heightFactor,
       duration: attributes.duration,
       curve: attributes.curve,
-      onEnd: onEndHandler(widget.controller),
+      onEnd: onEndHandler(
+        attributes.onEnd,
+        widget.controller.performAction,
+      ),
       child: widget.child,
     );
   }

--- a/lib/src/ui/widgets/implicit_animations/animated_container.dart
+++ b/lib/src/ui/widgets/implicit_animations/animated_container.dart
@@ -34,7 +34,10 @@ class _DuitAnimatedContainerState extends State<DuitAnimatedContainer>
       key: ValueKey(widget.controller.id),
       duration: attributes.duration,
       curve: attributes.curve,
-      onEnd: onEndHandler(widget.controller),
+      onEnd: onEndHandler(
+        attributes.onEnd,
+        widget.controller.performAction,
+      ),
       width: attributes.width,
       height: attributes.height,
       color: attributes.color,

--- a/lib/src/ui/widgets/implicit_animations/animated_opacity.dart
+++ b/lib/src/ui/widgets/implicit_animations/animated_opacity.dart
@@ -35,7 +35,10 @@ class _DuitAnimatedOpacityState extends State<DuitAnimatedOpacity>
       duration: attributes.duration,
       curve: attributes.curve,
       opacity: attributes.opacity,
-      onEnd: onEndHandler(widget.controller),
+      onEnd: onEndHandler(
+        attributes.onEnd,
+        widget.controller.performAction,
+      ),
       child: widget.child,
     );
   }

--- a/lib/src/ui/widgets/implicit_animations/animated_padding.dart
+++ b/lib/src/ui/widgets/implicit_animations/animated_padding.dart
@@ -35,7 +35,10 @@ class _DuitAnimatedPaddingState extends State<DuitAnimatedPadding>
       padding: attributes.padding,
       duration: attributes.duration,
       curve: attributes.curve,
-      onEnd: onEndHandler(widget.controller),
+      onEnd: onEndHandler(
+        attributes.onEnd,
+        widget.controller.performAction,
+      ),
       child: widget.child,
     );
   }

--- a/lib/src/ui/widgets/implicit_animations/animated_positioned.dart
+++ b/lib/src/ui/widgets/implicit_animations/animated_positioned.dart
@@ -38,6 +38,10 @@ class _DuitAnimatedPositionedState extends State<DuitAnimatedPositioned>
       left: attributes.left,
       duration: attributes.duration,
       curve: attributes.curve,
+      onEnd: onEndHandler(
+        attributes.onEnd,
+        widget.controller.performAction,
+      ),
       child: widget.child,
     );
   }

--- a/lib/src/ui/widgets/implicit_animations/animated_rotation.dart
+++ b/lib/src/ui/widgets/implicit_animations/animated_rotation.dart
@@ -37,6 +37,10 @@ class _DuitAnimatedRotationState extends State<DuitAnimatedRotation>
       filterQuality: attributes.filterQuality,
       turns: attributes.turns,
       curve: attributes.curve,
+      onEnd: onEndHandler(
+        attributes.onEnd,
+        widget.controller.performAction,
+      ),
       child: widget.child,
     );
   }

--- a/lib/src/ui/widgets/implicit_animations/animated_scale.dart
+++ b/lib/src/ui/widgets/implicit_animations/animated_scale.dart
@@ -22,12 +22,12 @@ class _DuitAnimatedScaleState extends State<DuitAnimatedScale>
         ViewControllerChangeListener<DuitAnimatedScale,
             AnimatedScaleAttributes>,
         OnAnimationEnd {
-
   @override
   void initState() {
     attachStateToController(widget.controller);
     super.initState();
   }
+
   @override
   Widget build(BuildContext context) {
     return AnimatedScale(
@@ -37,7 +37,10 @@ class _DuitAnimatedScaleState extends State<DuitAnimatedScale>
       alignment: attributes.alignment,
       curve: attributes.curve,
       filterQuality: attributes.filterQuality,
-      onEnd: onEndHandler(widget.controller),
+      onEnd: onEndHandler(
+        attributes.onEnd,
+        widget.controller.performAction,
+      ),
       child: widget.child,
     );
   }

--- a/lib/src/ui/widgets/implicit_animations/animated_size.dart
+++ b/lib/src/ui/widgets/implicit_animations/animated_size.dart
@@ -1,5 +1,6 @@
 import "package:flutter/material.dart";
 import "package:flutter_duit/flutter_duit.dart";
+import "package:flutter_duit/src/animations/index.dart";
 import "package:flutter_duit/src/attributes/animation_attributes/animated_size_attributes.dart";
 
 class DuitAnimatedSize extends StatefulWidget {
@@ -18,7 +19,8 @@ class DuitAnimatedSize extends StatefulWidget {
 
 class _DuitAnimatedSizeState extends State<DuitAnimatedSize>
     with
-        ViewControllerChangeListener<DuitAnimatedSize, AnimatedSizeAttributes> {
+        ViewControllerChangeListener<DuitAnimatedSize, AnimatedSizeAttributes>,
+        OnAnimationEnd {
   @override
   void initState() {
     attachStateToController(widget.controller);
@@ -34,6 +36,10 @@ class _DuitAnimatedSizeState extends State<DuitAnimatedSize>
       alignment: attributes.alignment ?? Alignment.center,
       curve: attributes.curve,
       reverseDuration: attributes.reverseDuration,
+      onEnd: onEndHandler(
+        attributes.onEnd,
+        widget.controller.performAction,
+      ),
       child: widget.child,
     );
   }

--- a/test/d_animated_align_test.dart
+++ b/test/d_animated_align_test.dart
@@ -36,4 +36,51 @@ void main() {
       expect(find.text("Some text"), findsOneWidget);
     },
   );
+
+  testWidgets("DuitAnimatedAlign must call onEnd", (tester) async {
+    final driver = DuitDriver.static(
+      {
+        "type": "AnimatedAlign",
+        "id": "align",
+        "attributes": {
+          "alignment": "bottomRight",
+          "duration": 100,
+          "onEnd": {
+            "executionType": 1, //local
+            "event": "local_exec",
+            "payload": {
+              "type": "update",
+              "updates": {
+                "text": {
+                  "data": "END",
+                },
+              }
+            },
+          },
+        },
+        "child": {
+          "type": "Text",
+          "id": "text",
+          "controlled": true,
+          "attributes": {
+            "data": "Some text",
+          },
+        }
+      },
+      transportOptions: EmptyTransportOptions(),
+    );
+
+    await pumpDriver(
+      tester,
+      driver,
+    );
+
+    await driver.updateTestAttributes("align", {
+      "alignment": "bottomLeft",
+    });
+
+    await tester.pumpAndSettle();
+
+    expect(find.text("END"), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Description

- Fixed onEnd callback for implicitly animated widgets
- Added onEnd callback for AnimatedSize widget
- Upd tests

## Issue

-

## Related PRs

-

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
