### PR TITLE
patch: ListView.separated separator behavior fix

### DIFF
--- a/lib/src/ui/models/element.dart
+++ b/lib/src/ui/models/element.dart
@@ -1073,10 +1073,12 @@ base class DuitElement<T> extends ElementTreeEntry<T> with WidgetFabric {
           id: id,
         );
 
-        bool isControlledByDefault = true;
+        bool isControlledByDefault = false;
 
         if (attributes.payload.type != 0) {
           isControlledByDefault = true;
+        } else {
+          isControlledByDefault = controlled;
         }
 
         final controlState = isControlledByDefault || controlled;
@@ -1378,7 +1380,7 @@ base class DuitElement<T> extends ElementTreeEntry<T> with WidgetFabric {
       case ElementType.empty:
         return EmptyUIElement<EmptyAttributes>();
       case ElementType.component:
-        final providedData = json["data"] as Map<String, dynamic>;
+        final providedData = Map<String, dynamic>.from(json["data"]);
 
         final model = DuitRegistry.getComponentDescription(tag!);
 

--- a/lib/src/ui/widgets/list/list_view_separated.dart
+++ b/lib/src/ui/widgets/list/list_view_separated.dart
@@ -18,8 +18,6 @@ class _DuitListViewSeparatedState extends State<DuitListViewSeparated>
         ViewControllerChangeListener<DuitListViewSeparated, ListViewAttributes>,
         ScrollUtils,
         OutOfBoundWidgetBuilder {
-  Widget? _separatorView;
-
   @override
   void initState() {
     attachStateToController(widget.controller);
@@ -40,14 +38,9 @@ class _DuitListViewSeparatedState extends State<DuitListViewSeparated>
   }
 
   Widget buildSeparator(BuildContext context, int index) {
-    if (_separatorView != null) {
-      return _separatorView!;
-    }
-
     final driver = widget.controller.driver;
-    return _separatorView =
-        buildOutOfBoundWidget(attributes.separator, driver, null) ??
-            const SizedBox.shrink();
+    return buildOutOfBoundWidget(attributes.separator, driver, null) ??
+        const SizedBox.shrink();
   }
 
   @override

--- a/test/d_listview_test.dart
+++ b/test/d_listview_test.dart
@@ -2,13 +2,22 @@ import "package:flutter/material.dart";
 import "package:flutter_duit/flutter_duit.dart";
 import "package:flutter_test/flutter_test.dart";
 
-Map<String, dynamic> _createWidget() {
+import "utils.dart";
+
+Map<String, dynamic> _createWidget(int type) {
   return {
     "controlled": true,
     "id": "87b54621-ac6d-42c3-8d1f-397e3bd63bca",
     "type": "ListView",
     "attributes": {
-      "type": 1,
+      "type": type,
+      "separator": <String, dynamic>{
+        "type": "Component",
+        "id": "sep1",
+        "controlled": true,
+        "data": {},
+        "tag": "sep"
+      },
       "childObjects": [
         {
           "controlled": true,
@@ -135,16 +144,173 @@ void main() {
               "height": 1000,
             },
           },
+        },
+        {
+          "tag": "sep",
+          "layoutRoot": {
+            "type": "Container",
+            "tag": "c",
+            "id": "ckk",
+            "controlled": false,
+            "attributes": {
+              "color": "#FCFCFC",
+              "width": 100,
+              "height": 12,
+            },
+          },
         }
       ]);
     },
   );
 
+  testWidgets("ListView must renders correctly", (tester) async {
+    final driver = DuitDriver.static(
+      {
+        "controlled": false,
+        "id": "list1",
+        "type": "ListView",
+        "attributes": {
+          "type": 0,
+          "itemExtent": 100.0,
+        },
+        "children": List.generate(
+            100,
+            (i) => <String, dynamic>{
+                  "type": "Container",
+                  "id": i.toString(),
+                  "controlled": false,
+                  "attributes": {
+                    "height": 100.0,
+                    "width": 100.0,
+                    "color": "#DCDCDC",
+                  },
+                }),
+      },
+      transportOptions: EmptyTransportOptions(),
+    );
+
+    await pumpDriver(
+      tester,
+      driver,
+    );
+
+    expect(find.byKey(const ValueKey("list1")), findsOneWidget);
+
+    final scroll = find.byType(Scrollable);
+    final itemFirst = find.byKey(const ValueKey("1"));
+    final itemLast = find.byKey(const ValueKey("99"));
+
+    await tester.scrollUntilVisible(
+      itemLast,
+      1000,
+      scrollable: scroll,
+    );
+
+    expect(itemLast, findsOneWidget);
+
+    await tester.scrollUntilVisible(
+      itemFirst,
+      -1000,
+      scrollable: scroll,
+    );
+
+    expect(itemFirst, findsOneWidget);
+  });
+
+  testWidgets("ListView must update attributes", (tester) async {
+    final driver = DuitDriver.static(
+      {
+        "controlled": true,
+        "id": "list1",
+        "type": "ListView",
+        "attributes": {
+          "type": 0,
+          "itemExtent": 100.0,
+        },
+        "children": List.generate(
+            100,
+            (i) => <String, dynamic>{
+                  "type": "Container",
+                  "id": i.toString(),
+                  "controlled": false,
+                  "attributes": {
+                    "height": 100.0,
+                    "width": 100.0,
+                    "color": "#DCDCDC",
+                  },
+                }),
+      },
+      transportOptions: EmptyTransportOptions(),
+    );
+
+    await pumpDriver(
+      tester,
+      driver,
+    );
+
+    ListView list = tester.widget(find.byKey(const ValueKey("list1")));
+
+    expect(list.itemExtent, 100.0);
+
+    await driver.updateTestAttributes("list1", {
+      "type": 0,
+      "itemExtent": 200.0,
+    });
+
+    await tester.pumpAndSettle();
+
+    list = tester.widget(find.byKey(const ValueKey("list1")));
+
+    expect(list.itemExtent, 200.0);
+  });
+
   testWidgets(
       "Checking the correct creation and destruction of component controllers when scrolling in ListView.builder",
       (tester) async {
     final driver = DuitDriver.static(
-      _createWidget(),
+      _createWidget(1),
+      transportOptions: EmptyTransportOptions(),
+    );
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: DuitViewHost(
+          driver: driver,
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final scroll = find.byType(Scrollable);
+    final itemFirst = find.byKey(const ValueKey("1"));
+    final itemLast = find.byKey(const ValueKey("10"));
+
+    await tester.scrollUntilVisible(
+      itemLast,
+      1000,
+      scrollable: scroll,
+    );
+
+    expect(itemLast, findsOneWidget);
+    expect(driver.controllersCount == 10, false);
+
+    await tester.scrollUntilVisible(
+      itemFirst,
+      -1000,
+      scrollable: scroll,
+    );
+
+    expect(itemFirst, findsOneWidget);
+    expect(driver.controllersCount == 10, false);
+  });
+
+  testWidgets(
+      "Checking the correct creation and destruction of component controllers when scrolling in ListView.separated",
+      (tester) async {
+    final driver = DuitDriver.static(
+      _createWidget(2),
       transportOptions: EmptyTransportOptions(),
     );
 


### PR DESCRIPTION
## Description

- Fixed calculation of the controlled property value for some widget usage scenarios
- Fixed separator operation error in the ListView.separated widget
- Updated tests for ListView

## Issue

---

## Related PRs

---

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
