### PR TITLE
breaking: Scaffold update

### DIFF
--- a/lib/src/ui/build_fn_lookup.dart
+++ b/lib/src/ui/build_fn_lookup.dart
@@ -22,7 +22,6 @@ const _buildFnLookup = <ElementType, BuildFn>{
   ElementType.align: _buildAlign,
   ElementType.transform: _buildTransform,
   ElementType.appBar: _buildAppBar,
-  ElementType.scaffold: _buildScaffold,
   ElementType.inkWell: _buildInkWell,
   ElementType.subtree: _buildSubtree,
   ElementType.meta: _buildMeta,
@@ -84,4 +83,5 @@ const _buildFnLookup = <ElementType, BuildFn>{
   ElementType.sliverList: _buildSliverList,
   ElementType.sliverGrid: _buildSliverGrid,
   ElementType.wrap: _buildWrap,
+  ElementType.scaffold: _buildScaffold,
 };

--- a/lib/src/ui/duit_element.dart
+++ b/lib/src/ui/duit_element.dart
@@ -105,13 +105,17 @@ final class DuitElement extends ElementTreeEntry {
         }
         return DuitElement._(element);
       case 2:
-        final children = JsonUtils.extractList<Map<String, dynamic>>(
+        final children = JsonUtils.extractList<Map<String, dynamic>?>(
           json,
           "children",
         );
         if (children.isNotEmpty) {
           for (final child in children) {
-            DuitElement.fromJson(child, driver);
+            //Safely handle null values at children list
+            //It`s important for some cases eg. as Scaffold sub-widgets passing
+            if (child != null) {
+              DuitElement.fromJson(child, driver);
+            }
           }
         }
         return DuitElement._(element);

--- a/lib/src/ui/element_property_view.dart
+++ b/lib/src/ui/element_property_view.dart
@@ -179,8 +179,8 @@ extension type ElementPropertyView._(Map<String, dynamic> json) {
   ///     .toList();
   /// ```
   @preferInline
-  List<ElementPropertyView> get children =>
-      JsonUtils.extractList<ElementPropertyView>(
+  List<ElementPropertyView?> get children =>
+      JsonUtils.extractList<ElementPropertyView?>(
         json,
         "children",
       );

--- a/lib/src/ui/element_type.dart
+++ b/lib/src/ui/element_type.dart
@@ -264,8 +264,8 @@ enum ElementType {
   ),
   scaffold(
     name: "Scaffold",
-    isControlledByDefault: true,
-    childRelation: 1,
+    isControlledByDefault: false,
+    childRelation: 2,
   ),
   inkWell(
     name: "InkWell",

--- a/lib/src/ui/widget_from_element.dart
+++ b/lib/src/ui/widget_from_element.dart
@@ -185,10 +185,16 @@ Widget _buildAppBar(ElementPropertyView model) => DuitAppBar(
       controller: model.viewController,
     );
 
-Widget _buildScaffold(ElementPropertyView model) => DuitScaffold(
-      controller: model.viewController,
-      child: _buildWidget(model.child),
-    );
+Widget _buildScaffold(ElementPropertyView model) => switch (model.controlled) {
+      true => DuitControlledScaffold(
+          controller: model.viewController,
+          children: model.children.map(_buildWidget).toList(),
+        ),
+      false => DuitScaffold(
+          attributes: model.attributes,
+          children: model.children.map(_buildWidget).toList(),
+        ),
+    };
 
 Widget _buildPositioned(ElementPropertyView model) {
   return switch (model.controlled) {

--- a/lib/src/ui/widget_from_element.dart
+++ b/lib/src/ui/widget_from_element.dart
@@ -185,16 +185,22 @@ Widget _buildAppBar(ElementPropertyView model) => DuitAppBar(
       controller: model.viewController,
     );
 
-Widget _buildScaffold(ElementPropertyView model) => switch (model.controlled) {
-      true => DuitControlledScaffold(
-          controller: model.viewController,
-          children: model.children.map(_buildWidget).toList(),
-        ),
-      false => DuitScaffold(
-          attributes: model.attributes,
-          children: model.children.map(_buildWidget).toList(),
-        ),
-    };
+Widget _buildScaffold(ElementPropertyView model) {
+  final children = model.children
+      .map<Widget?>((c) => c == null ? null : _buildWidget(c))
+      .toList();
+
+  return switch (model.controlled) {
+    true => DuitControlledScaffold(
+        controller: model.viewController,
+        children: children,
+      ),
+    false => DuitScaffold(
+        attributes: model.attributes,
+        children: children,
+      ),
+  };
+}
 
 Widget _buildPositioned(ElementPropertyView model) {
   return switch (model.controlled) {

--- a/lib/src/ui/widgets/carouse_view.dart
+++ b/lib/src/ui/widgets/carouse_view.dart
@@ -20,12 +20,13 @@ final class DuitCarouselView extends StatelessWidget with AnimatedAttributes {
 
     return CarouselView(
       key: Key(attributes.id),
+      padding: attrs.edgeInsets(),
       itemExtent: attrs.getDouble(key: "itemExtent"),
       backgroundColor: attrs.tryParseColor(key: "backgroundColor"),
       elevation: attrs.tryGetDouble(key: "elevation"),
       shape: attrs.shapeBorder(),
       overlayColor: attrs.widgetStateProperty<Color>(key: "overlayColor"),
-      itemSnapping: attrs.getBool("itemSnapping", defaultValue: true),
+      itemSnapping: attrs.getBool("itemSnapping", defaultValue: false),
       shrinkExtent: attrs.getDouble(key: "shrinkExtent"),
       scrollDirection: attrs.axis(defaultValue: Axis.horizontal),
       reverse: attrs.getBool("reverse"),
@@ -67,6 +68,7 @@ class _DuitControlledCarouselViewState extends State<DuitControlledCarouselView>
 
     return CarouselView(
       key: Key(widget.controller.id),
+      padding: attrs.edgeInsets(),
       itemExtent: attrs.getDouble(key: "itemExtent"),
       backgroundColor: attrs.tryParseColor(key: "backgroundColor"),
       elevation: attrs.tryGetDouble(key: "elevation"),

--- a/lib/src/ui/widgets/scaffold.dart
+++ b/lib/src/ui/widgets/scaffold.dart
@@ -1,8 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_duit/flutter_duit.dart';
 
+const _kBodyIndex = 0,
+    _kAppBarIndex = 1,
+    _kFabIndex = 2,
+    _kBottomSheetIndex = 3,
+    _kBottomNavInvdex = 4,
+    _kPersistentButtonsFirstIndex = 5;
+
 PreferredSizeWidget? _buildAppBar(List<Widget?> children) {
-  final appBar = children.elementAtOrNull(1);
+  final appBar = children.elementAtOrNull(_kAppBarIndex);
   return appBar is PreferredSizeWidget ? appBar : null;
 }
 
@@ -21,13 +28,13 @@ final class DuitScaffold extends StatelessWidget {
     final attrs = attributes.payload;
     return Scaffold(
       key: Key(attributes.id),
-      body: children.elementAtOrNull(0),
+      body: children.elementAtOrNull(_kBodyIndex),
       appBar: _buildAppBar(children),
-      floatingActionButton: children.elementAtOrNull(2),
-      bottomSheet: children.elementAtOrNull(3),
-      bottomNavigationBar: children.elementAtOrNull(4),
-      persistentFooterButtons: children.length > 5
-          ? children.sublist(5).whereType<Widget>().toList()
+      floatingActionButton: children.elementAtOrNull(_kFabIndex),
+      bottomSheet: children.elementAtOrNull(_kBottomSheetIndex),
+      bottomNavigationBar: children.elementAtOrNull(_kBottomNavInvdex),
+      persistentFooterButtons: children.length > _kPersistentButtonsFirstIndex
+          ? children.sublist(_kPersistentButtonsFirstIndex).whereType<Widget>().toList()
           : null,
       floatingActionButtonLocation: attrs.fabLocation(),
       primary: attrs.getBool("primary", defaultValue: true),
@@ -70,13 +77,13 @@ class _DuitControlledScaffoldState extends State<DuitControlledScaffold>
     final children = widget.children;
     return Scaffold(
       key: Key(widget.controller.id),
-      body: children.elementAtOrNull(0),
+      body: children.elementAtOrNull(_kBodyIndex),
       appBar: _buildAppBar(children),
-      floatingActionButton: children.elementAtOrNull(2),
-      bottomSheet: children.elementAtOrNull(3),
-      bottomNavigationBar: children.elementAtOrNull(4),
-      persistentFooterButtons: children.length > 5
-          ? children.sublist(5).whereType<Widget>().toList()
+      floatingActionButton: children.elementAtOrNull(_kFabIndex),
+      bottomSheet: children.elementAtOrNull(_kBottomSheetIndex),
+      bottomNavigationBar: children.elementAtOrNull(_kBottomNavInvdex),
+      persistentFooterButtons: children.length > _kPersistentButtonsFirstIndex
+          ? children.sublist(_kPersistentButtonsFirstIndex).whereType<Widget>().toList()
           : null,
       floatingActionButtonLocation: attributes.fabLocation(),
       primary: attributes.getBool("primary", defaultValue: true),

--- a/lib/src/ui/widgets/scaffold.dart
+++ b/lib/src/ui/widgets/scaffold.dart
@@ -1,22 +1,64 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_duit/flutter_duit.dart';
 
-class DuitScaffold extends StatefulWidget {
-  final UIElementController controller;
-  final Widget child;
+PreferredSizeWidget? _buildAppBar(List<Widget?> children) {
+  final appBar = children.elementAtOrNull(1);
+  return appBar is PreferredSizeWidget ? appBar : null;
+}
+
+final class DuitScaffold extends StatelessWidget {
+  final ViewAttribute attributes;
+  final List<Widget?> children;
 
   const DuitScaffold({
     super.key,
-    required this.controller,
-    required this.child,
+    required this.attributes,
+    required this.children,
   });
 
   @override
-  State<DuitScaffold> createState() => _DuitScaffoldState();
+  Widget build(BuildContext context) {
+    final attrs = attributes.payload;
+    return Scaffold(
+      key: Key(attributes.id),
+      body: children.elementAtOrNull(0),
+      appBar: _buildAppBar(children),
+      floatingActionButton: children.elementAtOrNull(2),
+      bottomSheet: children.elementAtOrNull(3),
+      bottomNavigationBar: children.elementAtOrNull(4),
+      persistentFooterButtons: children.length > 5
+          ? children.sublist(5).whereType<Widget>().toList()
+          : null,
+      floatingActionButtonLocation: attrs.fabLocation(),
+      primary: attrs.getBool("primary", defaultValue: true),
+      extendBody: attrs.getBool("extendBody"),
+      extendBodyBehindAppBar: attrs.getBool("extendBodyBehindAppBar"),
+      persistentFooterAlignment: attrs.alignmentDirectional(
+        defaultValue: AlignmentDirectional.centerEnd,
+      )!,
+      restorationId: attrs.tryGetString("restorationId"),
+      resizeToAvoidBottomInset: attrs.tryGetBool("resizeToAvoidBottomInset"),
+      backgroundColor: attrs.tryParseColor(key: "backgroundColor"),
+    );
+  }
 }
 
-class _DuitScaffoldState extends State<DuitScaffold>
-    with ViewControllerChangeListener, OutOfBoundWidgetBuilder {
+final class DuitControlledScaffold extends StatefulWidget {
+  final UIElementController controller;
+  final List<Widget?> children;
+
+  const DuitControlledScaffold({
+    super.key,
+    required this.controller,
+    required this.children,
+  });
+
+  @override
+  State<DuitControlledScaffold> createState() => _DuitControlledScaffoldState();
+}
+
+class _DuitControlledScaffoldState extends State<DuitControlledScaffold>
+    with ViewControllerChangeListener {
   @override
   void initState() {
     attachStateToController(widget.controller);
@@ -25,40 +67,23 @@ class _DuitScaffoldState extends State<DuitScaffold>
 
   @override
   Widget build(BuildContext context) {
-    final driver = widget.controller.driver;
+    final children = widget.children;
     return Scaffold(
       key: Key(widget.controller.id),
-      appBar: buildOutOfBoundWidget(
-        attributes["appBar"],
-        driver,
-        null,
-      ),
-      body: widget.child,
-      floatingActionButton: buildOutOfBoundWidget(
-        attributes["floatingActionButton"],
-        driver,
-        null,
-      ),
-      bottomSheet: buildOutOfBoundWidget(
-        attributes["bottomSheet"],
-        driver,
-        null,
-      ),
-      bottomNavigationBar: buildOutOfBoundWidget(
-        attributes["bottomNavigationBar"],
-        driver,
-        null,
-      ),
+      body: children.elementAtOrNull(0),
+      appBar: _buildAppBar(children),
+      floatingActionButton: children.elementAtOrNull(2),
+      bottomSheet: children.elementAtOrNull(3),
+      bottomNavigationBar: children.elementAtOrNull(4),
+      persistentFooterButtons: children.length > 5
+          ? children.sublist(5).whereType<Widget>().toList()
+          : null,
       floatingActionButtonLocation: attributes.fabLocation(),
       primary: attributes.getBool("primary", defaultValue: true),
       extendBody: attributes.getBool("extendBody"),
       extendBodyBehindAppBar: attributes.getBool("extendBodyBehindAppBar"),
       persistentFooterAlignment: attributes.alignmentDirectional(
           defaultValue: AlignmentDirectional.centerEnd)!,
-      persistentFooterButtons: (attributes["persistentFooterButtons"] as List?)
-          ?.map((e) => buildOutOfBoundWidget(e, driver, null))
-          .whereType<Widget>()
-          .toList(),
       restorationId: attributes.tryGetString("restorationId"),
       resizeToAvoidBottomInset:
           attributes.tryGetBool("resizeToAvoidBottomInset"),

--- a/test/d_scaffold_test.dart
+++ b/test/d_scaffold_test.dart
@@ -44,14 +44,16 @@ void main() {
               "type": "Scaffold",
               "id": "scaffold",
               "attributes": <String, dynamic>{},
-              "child": {
-                "type": "Text",
-                "id": "text",
-                "controlled": false,
-                "attributes": {
-                  "data": "Hello, world!",
+              "children": [
+                {
+                  "type": "Text",
+                  "id": "text",
+                  "controlled": false,
+                  "attributes": {
+                    "data": "Hello, world!",
+                  },
                 },
-              },
+              ],
             },
             transportOptions: EmptyTransportOptions(),
           );
@@ -75,14 +77,15 @@ void main() {
               {
                 "type": "Scaffold",
                 "id": "scaffold",
-                "attributes": {
-                  "appBar": {
+                "children": [
+                  null,
+                  {
                     "type": "AppBar",
                     "id": "appBar",
                     "controlled": true,
                     "attributes": <String, dynamic>{},
                   },
-                },
+                ]
               },
               transportOptions: EmptyTransportOptions(),
             ),
@@ -100,14 +103,17 @@ void main() {
             {
               "type": "Scaffold",
               "id": "scaffold",
-              "attributes": {
-                "bottomSheet": {
+              "children": [
+                null,
+                null,
+                null,
+                {
                   "type": "Container",
                   "id": "bottom",
                   "controlled": false,
                   "attributes": {"height": 100, "color": "#00FF00"},
                 },
-              },
+              ],
             },
             transportOptions: EmptyTransportOptions(),
           );
@@ -129,8 +135,10 @@ void main() {
             {
               "type": "Scaffold",
               "id": "scaffold",
-              "attributes": {
-                "floatingActionButton": {
+              "children": [
+                null,
+                null,
+                {
                   "type": "Container",
                   "id": "bottom",
                   "controlled": false,
@@ -140,7 +148,8 @@ void main() {
                     "color": "#00FF00",
                   },
                 },
-              },
+                null,
+              ],
             },
             transportOptions: EmptyTransportOptions(),
           );


### PR DESCRIPTION
feat: Updated Scaffold structure and handled children with possible null values

- Changed the structure of the DuitScaffold class to support a list of children instead of a single child.
- Added handling of possible null values ​​in the list of children.
- Updated the relevant tests to check the new structure.

## Description

<!--- Describe your changes in detail -->

## Issue

<!--- Add link to issue here -->

## Related PRs

- https://github.com/Duit-Foundation/duit_go/pull/131

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Scaffold now supports multiple slots via a unified children list and offers controlled + uncontrolled variants.
  - Carousel gains configurable padding for improved layout.

- Behavior Changes
  - Carousel item snapping defaults to off.

- Bug Fixes
  - More robust handling when child entries are null or missing.

- Refactor
  - Scaffold architecture migrated to an attributes + children model.

- Tests
  - Tests updated to match children-based scaffold composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->