### PR TITLE
breaking: FlexibleSpaceBar update

### DIFF
--- a/lib/src/ui/build_fn_lookup.dart
+++ b/lib/src/ui/build_fn_lookup.dart
@@ -1,4 +1,4 @@
-part of 'element_property_view.dart';
+part of "element_property_view.dart";
 
 typedef BuildFn = Widget Function(ElementPropertyView);
 
@@ -55,7 +55,6 @@ const _buildFnLookup = <ElementType, BuildFn>{
   ElementType.ignorePointer: _buildIgnorePointer,
   ElementType.opacity: _buildOpacity,
   ElementType.fittedBox: _buildFittedBox,
-  ElementType.flexibleSpaceBar: _buildFlexibleSpaceBar,
   ElementType.sliverPadding: _buildSliverPadding,
   ElementType.customScrollView: _buildCustomScrollView,
   ElementType.sliverFillRemaining: _buildSliverFillRemaining,
@@ -84,4 +83,5 @@ const _buildFnLookup = <ElementType, BuildFn>{
   ElementType.scaffold: _buildScaffold,
   ElementType.sliverVisibility: _buildSliverVisibility,
   ElementType.sliverAppBar: _buildSliverAppBar,
+  ElementType.flexibleSpaceBar: _buildFlexibleSpaceBar,
 };

--- a/lib/src/ui/element_type.dart
+++ b/lib/src/ui/element_type.dart
@@ -309,8 +309,8 @@ enum ElementType {
   ),
   flexibleSpaceBar(
     name: "FlexibleSpaceBar",
-    isControlledByDefault: true,
-    childRelation: 0,
+    isControlledByDefault: false,
+    childRelation: 2,
   ),
   sliverPadding(
     name: "SliverPadding",

--- a/lib/src/ui/widget_from_element.dart
+++ b/lib/src/ui/widget_from_element.dart
@@ -571,11 +571,20 @@ Widget _buildPhysicalModel(ElementPropertyView model) {
   };
 }
 
-// Sliver widgets - mostly controlled only
-Widget _buildFlexibleSpaceBar(ElementPropertyView model) =>
-    DuitFlexibleSpaceBar(
-      controller: model.viewController,
-    );
+Widget _buildFlexibleSpaceBar(ElementPropertyView model) {
+  final children = _mapToNullableWidgetList(model);
+
+  return switch (model.controlled) {
+    true => DuitControlledFlexibleSpaceBar(
+        controller: model.viewController,
+        children: children,
+      ),
+    false => DuitFlexibleSpaceBar(
+        attributes: model.attributes,
+        children: children,
+      ),
+  };
+}
 
 Widget _buildSliverPadding(ElementPropertyView model) {
   return switch (model.controlled) {

--- a/lib/src/ui/widgets/flexible_space_bar.dart
+++ b/lib/src/ui/widgets/flexible_space_bar.dart
@@ -1,35 +1,60 @@
-import 'package:flutter/material.dart';
-import 'package:flutter_duit/flutter_duit.dart';
+import "package:flutter/material.dart";
+import "package:flutter_duit/flutter_duit.dart";
 
-class DuitFlexibleSpaceBar extends StatefulWidget with AnimatedAttributes {
-  final UIElementController controller;
+const _kTitleIndex = 0, _kBackgroundIndex = 1;
+
+class DuitFlexibleSpaceBar extends StatelessWidget with AnimatedAttributes {
+  final ViewAttribute attributes;
+  final List<Widget?> children;
 
   const DuitFlexibleSpaceBar({
+    required this.attributes,
+    required this.children,
     super.key,
-    required this.controller,
   });
 
   @override
-  State<DuitFlexibleSpaceBar> createState() => _DuitFlexibleSpaceBarState();
+  Widget build(BuildContext context) {
+    final attrs = mergeWithDataSource(context, attributes.payload);
+    return FlexibleSpaceBar(
+      key: ValueKey(attributes.id),
+      title: children.elementAtOrNull(_kTitleIndex),
+      background: children.elementAtOrNull(_kBackgroundIndex),
+      centerTitle: attrs.tryGetBool("centerTitle"),
+      expandedTitleScale: attrs.getDouble(
+        key: "expandedTitleScale",
+        defaultValue: 1.5,
+      ),
+      collapseMode: attrs.collapseMode(),
+      stretchModes: attrs.stretchModes(),
+      titlePadding: attrs.edgeInsets(key: "titlePadding"),
+    );
+  }
 }
 
-class _DuitFlexibleSpaceBarState extends State<DuitFlexibleSpaceBar>
-    with ViewControllerChangeListener, OutOfBoundWidgetBuilder {
+class DuitControlledFlexibleSpaceBar extends StatefulWidget
+    with AnimatedAttributes {
+  final UIElementController controller;
+  final List<Widget?> children;
+
+  const DuitControlledFlexibleSpaceBar({
+    required this.controller,
+    required this.children,
+    super.key,
+  });
+
+  @override
+  State<DuitControlledFlexibleSpaceBar> createState() =>
+      _DuitControlledFlexibleSpaceBarState();
+}
+
+class _DuitControlledFlexibleSpaceBarState
+    extends State<DuitControlledFlexibleSpaceBar>
+    with ViewControllerChangeListener {
   @override
   void initState() {
     attachStateToController(widget.controller);
     super.initState();
-  }
-
-  Widget? _build(NonChildWidget? child) {
-    if (child == null) {
-      return null;
-    }
-    return buildOutOfBoundWidget(
-      child,
-      widget.controller.driver,
-      null,
-    );
   }
 
   @override
@@ -37,8 +62,8 @@ class _DuitFlexibleSpaceBarState extends State<DuitFlexibleSpaceBar>
     final attrs = widget.mergeWithDataSource(context, attributes);
     return FlexibleSpaceBar(
       key: ValueKey(widget.controller.id),
-      title: _build(attrs["title"]),
-      background: _build(attrs["background"]),
+      title: widget.children.elementAtOrNull(_kTitleIndex),
+      background: widget.children.elementAtOrNull(_kBackgroundIndex),
       centerTitle: attrs.tryGetBool("centerTitle"),
       expandedTitleScale: attrs.getDouble(
         key: "expandedTitleScale",

--- a/test/d_flexible_space_bar_and_sliver_app_bar_test.dart
+++ b/test/d_flexible_space_bar_and_sliver_app_bar_test.dart
@@ -55,8 +55,8 @@ Map<String, dynamic> _createWidget({
               "type": "FlexibleSpaceBar",
               "id": "flexibleSpaceBarId",
               "controlled": controlledFlexibleSpaceBar,
-              "attributes": {
-                "title": {
+              "children": [
+                {
                   "type": "Text",
                   "id": "title",
                   "controlled": false,
@@ -69,26 +69,28 @@ Map<String, dynamic> _createWidget({
                     },
                   },
                 },
-                "background": {
+                {
                   "type": "Container",
                   "id": "background",
                   "controlled": false,
                   "attributes": {
                     "color": "#2196F3",
-                    "child": {
-                      "type": "Text",
-                      "id": "backgroundText",
-                      "controlled": false,
-                      "attributes": {
-                        "data": "Background",
-                        "style": {
-                          "color": "#FFFFFF",
-                          "fontSize": 16.0,
-                        },
+                  },
+                  "child": {
+                    "type": "Text",
+                    "id": "backgroundText",
+                    "controlled": false,
+                    "attributes": {
+                      "data": "Background",
+                      "style": {
+                        "color": "#FFFFFF",
+                        "fontSize": 16.0,
                       },
                     },
                   },
                 },
+              ],
+              "attributes": {
                 "centerTitle": true,
                 "expandedTitleScale": 1.5,
                 "collapseMode": "parallax",
@@ -191,6 +193,15 @@ void main() {
         final flexibleSpaceBar =
             find.byKey(const ValueKey("flexibleSpaceBarId"));
         expect(flexibleSpaceBar, findsOneWidget);
+
+        final title = find.byKey(const ValueKey("title"));
+        expect(title, findsOneWidget);
+
+        final background = find.byKey(const ValueKey("background"));
+        expect(background, findsOneWidget);
+
+        final backgroundText = find.text("Background");
+        expect(backgroundText, findsOneWidget);
       },
     );
 


### PR DESCRIPTION
## Description

Upd FlexibleSpaceBar widget, upd tests

## Issue

<!--- Add link to issue here -->

## Related PRs

- https://github.com/Duit-Foundation/duit_go/pull/134

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - FlexibleSpaceBar now supports both controlled and uncontrolled usage.
  - Title and background can be provided as child widgets for greater composability.

- Refactor
  - DuitFlexibleSpaceBar converted to a stateless widget with a new constructor (attributes + children).
  - FlexibleSpaceBar elements are no longer controlled by default and now support multiple children.

- Tests
  - Updated tests to reflect children-based title/background structure.

- Style
  - Minor formatting adjustments (quote style, map entry order) with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->