### PR TITLE
feat: FilledButton widget

### DIFF
--- a/lib/src/ui/build_fn_lookup.dart
+++ b/lib/src/ui/build_fn_lookup.dart
@@ -14,6 +14,7 @@ const _buildFnLookup = <ElementType, BuildFn>{
   // Single-child elements
   ElementType.elevatedButton: _buildElevatedButton,
   ElementType.outlinedButton: _buildOutlinedButton,
+  ElementType.filledButton: _buildFilledButton,
   ElementType.animatedBuilder: _buildAnimatedBuilder,
   ElementType.absorbPointer: _buildAbsorbPointer,
   ElementType.offstage: _buildOffstage,

--- a/lib/src/ui/element_type.dart
+++ b/lib/src/ui/element_type.dart
@@ -112,6 +112,12 @@ enum ElementType {
     childRelation: 1,
     mayHaveRelatedAction: true,
   ),
+  filledButton(
+    name: "FilledButton",
+    isControlledByDefault: true,
+    childRelation: 1,
+    mayHaveRelatedAction: true,
+  ),
   positioned(
     name: "Positioned",
     isControlledByDefault: false,
@@ -618,6 +624,7 @@ const _stringToTypeLookupTable = <String, ElementType>{
   "Center": ElementType.center,
   "ElevatedButton": ElementType.elevatedButton,
   "OutlinedButton": ElementType.outlinedButton,
+  "FilledButton": ElementType.filledButton,
   "Positioned": ElementType.positioned,
   "Align": ElementType.align,
   "Transform": ElementType.transform,

--- a/lib/src/ui/theme/preprocessor.dart
+++ b/lib/src/ui/theme/preprocessor.dart
@@ -133,6 +133,7 @@ final class DuitThemePreprocessor extends ThemePreprocessor {
         ),
       ElementType.elevatedButton ||
       ElementType.outlinedButton ||
+      ElementType.filledButton ||
       ElementType.center ||
       ElementType.clipRect ||
       ElementType.clipOval ||

--- a/lib/src/ui/widget_from_element.dart
+++ b/lib/src/ui/widget_from_element.dart
@@ -55,6 +55,13 @@ Widget _buildOutlinedButton(ElementPropertyView model) {
   );
 }
 
+Widget _buildFilledButton(ElementPropertyView model) {
+  return DuitFilledButton(
+    controller: model.viewController,
+    child: _buildWidget(model.child),
+  );
+}
+
 
 Widget _buildTextField(ElementPropertyView model) => DuitTextField(
       controller: model.viewController,

--- a/lib/src/ui/widgets/filled_button.dart
+++ b/lib/src/ui/widgets/filled_button.dart
@@ -1,0 +1,82 @@
+import "package:duit_kernel/duit_kernel.dart";
+import "package:flutter/material.dart";
+import "package:flutter_duit/src/duit_impl/index.dart";
+
+final class DuitFilledButton extends StatefulWidget {
+  final UIElementController controller;
+  final Widget child;
+
+  const DuitFilledButton({
+    required this.controller,
+    required this.child,
+    super.key,
+  });
+
+  @override
+  State<DuitFilledButton> createState() => _DuitFilledButtonState();
+}
+
+class _DuitFilledButtonState extends State<DuitFilledButton>
+    with ViewControllerChangeListener {
+  late final FocusNode _focusNode;
+
+  @override
+  void initState() {
+    final controller = widget.controller;
+    attachStateToController(controller);
+
+    _focusNode = attributes.focusNode(
+      defaultValue: FocusNode(),
+    )!;
+
+    controller.driver.attachFocusNode(
+      widget.controller.id,
+      _focusNode,
+    );
+
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    widget.controller.driver.detachFocusNode(widget.controller.id);
+    super.dispose();
+  }
+
+  void _onLongPress() {
+    final action = attributes.getAction("onLongPress");
+    if (action != null) {
+      widget.controller.performAction(action);
+    }
+  }
+
+  void _onFocusChange(bool _) {
+    final action = attributes.getAction("onFocusChange");
+    if (action != null) {
+      widget.controller.performAction(action);
+    }
+  }
+
+  void _onHover(bool _) {
+    final action = attributes.getAction("onHover");
+    if (action != null) {
+      widget.controller.performAction(action);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FilledButton(
+      key: ValueKey(widget.controller.id),
+      focusNode: _focusNode,
+      autofocus: attributes.getBool("autofocus"),
+      clipBehavior: attributes.clipBehavior(),
+      onPressed: widget.controller.performRelatedAction,
+      style: attributes.buttonStyle(),
+      onLongPress: _onLongPress,
+      onFocusChange: _onFocusChange,
+      onHover: _onHover,
+      child: widget.child,
+    );
+  }
+}

--- a/lib/src/ui/widgets/index.dart
+++ b/lib/src/ui/widgets/index.dart
@@ -1,5 +1,7 @@
 export "text.dart";
 export "elevated_button.dart";
+export "outlined_button.dart";
+export "filled_button.dart";
 export "row.dart";
 export "column.dart";
 export "sized_box.dart";
@@ -24,7 +26,6 @@ export "single_child_scrollview.dart";
 export "radio.dart";
 export "ignore_pointer.dart";
 export "opacity.dart";
-export "outlined_button.dart";
 export "slider.dart";
 export "fitted_box.dart";
 export "switch.dart";

--- a/test/d_filled_button_test.dart
+++ b/test/d_filled_button_test.dart
@@ -1,0 +1,210 @@
+import "dart:ui";
+
+import "package:duit_kernel/duit_kernel.dart";
+import "package:flutter/material.dart";
+import "package:flutter_duit/flutter_duit.dart";
+import "package:flutter_test/flutter_test.dart";
+
+Map<String, dynamic> _createWidget() {
+  return {
+    "type": "FilledButton",
+    "id": "bId",
+    "controlled": true,
+    "action": LocalAction(
+      event: UpdateEvent(
+        updates: {
+          "t1": {
+            "data": "Pressed!",
+            "style":
+                const TextStyle(fontSize: 24.0, fontWeight: FontWeight.w800),
+          },
+        },
+      ),
+    ),
+    "attributes": {
+      "autofocus": false,
+      "onLongPress": LocalAction(
+        event: UpdateEvent(
+          updates: {
+            "t1": {
+              "data": "Long pressed!",
+              "style":
+                  const TextStyle(fontSize: 48.0, fontWeight: FontWeight.w400),
+            },
+          },
+        ),
+      ),
+      "onFocusChange": LocalAction(
+        event: UpdateEvent(
+          updates: {
+            "t1": {
+              "data": "Focused!",
+              "style":
+                  const TextStyle(fontSize: 32.0, fontWeight: FontWeight.w700),
+            },
+          },
+        ),
+      ),
+      "onHover": LocalAction(
+        event: UpdateEvent(
+          updates: {
+            "t1": {
+              "data": "Hovered!",
+              "style":
+                  const TextStyle(fontSize: 20.0, fontWeight: FontWeight.w600),
+            },
+          },
+        ),
+      ),
+    },
+    "child": {
+      "type": "Text",
+      "id": "t1",
+      "controlled": true,
+      "attributes": {
+        "data": "Press me!",
+        "style": const TextStyle(fontSize: 12.0, fontWeight: FontWeight.w400),
+      },
+    },
+  };
+}
+
+void main() {
+  group(
+    "DuitFilledButton widget tests",
+    () {
+      testWidgets("check pressed and key assignment", (t) async {
+        await t.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: DuitViewHost.withDriver(
+              driver: XDriver.static(
+                _createWidget(),
+              ),
+            ),
+          ),
+        );
+
+        await t.pumpAndSettle();
+
+        final button = find.byKey(const Key("bId"));
+
+        expect(button, findsOneWidget);
+
+        await t.tap(button);
+
+        await t.pumpAndSettle();
+
+        expect(find.text("Pressed!"), findsOneWidget);
+      });
+
+      testWidgets("check action execution", (tester) async {
+        final driver = XDriver.static(
+          _createWidget(),
+        );
+
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: DuitViewHost.withDriver(
+              driver: driver,
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        final button = find.byKey(const Key("bId"));
+
+        await tester.tap(button);
+
+        await tester.pumpAndSettle();
+
+        var text = find.text("Pressed!");
+        expect(text, findsOneWidget);
+
+        var widget = tester.widget<Text>(text);
+
+        expect(widget.style?.fontWeight, equals(FontWeight.w800));
+        expect(widget.style?.fontSize, equals(24.0));
+
+        await tester.longPress(button);
+        await tester.pumpAndSettle();
+
+        text = find.text("Long pressed!");
+        expect(text, findsOneWidget);
+
+        widget = tester.widget<Text>(text);
+        expect(text, findsOneWidget);
+        expect(widget.style?.fontWeight, equals(FontWeight.w400));
+        expect(widget.style?.fontSize, equals(48.0));
+      });
+
+      testWidgets("check onFocusChange callback", (tester) async {
+        final driver = XDriver.static(
+          _createWidget(),
+        );
+
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: DuitViewHost.withDriver(
+              driver: driver,
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        // Request focus on button (requestFocus is a synchronous method)
+        driver.requestFocus("bId");
+        await tester.pumpAndSettle();
+
+        var text = find.text("Focused!");
+        expect(text, findsOneWidget);
+
+        var widget = tester.widget<Text>(text);
+        expect(widget.style?.fontWeight, equals(FontWeight.w700));
+        expect(widget.style?.fontSize, equals(32.0));
+      });
+
+      testWidgets("check onHover callback", (tester) async {
+        final driver = XDriver.static(
+          _createWidget(),
+        );
+
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: DuitViewHost.withDriver(
+              driver: driver,
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        final button = find.byKey(const Key("bId"));
+
+        // Create a mouse gesture for hover testing
+        final gesture = await tester.createGesture(
+          kind: PointerDeviceKind.mouse,
+        );
+
+        // Add pointer and move to button center
+        await gesture.addPointer(location: Offset.zero);
+        await tester.pumpAndSettle();
+
+        await gesture.moveTo(tester.getCenter(button));
+        await tester.pumpAndSettle();
+
+        var text = find.text("Hovered!");
+        expect(text, findsOneWidget);
+
+        var widget = tester.widget<Text>(text);
+        expect(widget.style?.fontWeight, equals(FontWeight.w600));
+        expect(widget.style?.fontSize, equals(20.0));
+      });
+    },
+  );
+}


### PR DESCRIPTION
## Description

- Added new widget

## Issue

#243 

## Related PRs

- https://github.com/Duit-Foundation/duit_go/pull/156

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FilledButton widget support, enabling developers to create filled button elements with comprehensive event handling including press, long-press, focus-change, and hover actions.

* **Tests**
  * Added comprehensive test suite for FilledButton widget covering press, long-press, focus, and hover interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->